### PR TITLE
Apply factory pattern. 

### DIFF
--- a/app/services/location/jhu.py
+++ b/app/services/location/jhu.py
@@ -16,6 +16,7 @@ from ...utils import countries
 from ...utils import date as date_util
 from ...utils import httputils
 from . import LocationService
+from . import ModelFactory
 
 LOGGER = logging.getLogger("services.location.jhu")
 PID = os.getpid()
@@ -155,6 +156,9 @@ async def get_locations():
     #       incorrect data to consumers.
     # ***************************************************************************
     # Go through locations.
+    modelFactory = ModelFactory()
+    model_type = "timeline"
+
     for index, location in enumerate(locations_confirmed):
         # Get the timelines.
 
@@ -183,19 +187,19 @@ async def get_locations():
                 datetime.utcnow().isoformat() + "Z",
                 # Timelines (parse dates as ISO).
                 {
-                    "confirmed": Timeline(
-                        timeline={
+                    "confirmed": modelFactory.create_model(model_type,
+                        {
                             datetime.strptime(date, "%m/%d/%y").isoformat() + "Z": amount
                             for date, amount in timelines["confirmed"].items()
                         }
                     ),
-                    "deaths": Timeline(
-                        timeline={
+                    "deaths": modelFactory.create_model(model_type,
+                        {
                             datetime.strptime(date, "%m/%d/%y").isoformat() + "Z": amount
                             for date, amount in timelines["deaths"].items()
                         }
                     ),
-                    "recovered": Timeline(
+                    "recovered": modelFactory.create_model(model_type,
                         timeline={
                             datetime.strptime(date, "%m/%d/%y").isoformat() + "Z": amount
                             for date, amount in timelines["recovered"].items()

--- a/app/services/location/modelfactory.py
+++ b/app/services/location/modelfactory.py
@@ -1,4 +1,5 @@
 from ...models import *
+
 class ModelFactory():
     def create_model(self, type, data):
         """Factory Method"""

--- a/app/services/location/modelfactory.py
+++ b/app/services/location/modelfactory.py
@@ -2,11 +2,11 @@ from ...models import *
 class ModelFactory():
     def create_model(self, type, data):
         """Factory Method"""
-        localizers = {
+        models = {
             "timeline": Timeline(timeline = data),
             "latest": Latest(confirmed = data.confirmed, deaths = data.deaths, recovered = data.recovered),
             "timelines": Timelines(confirmed = data.confirmed, deaths = data.deaths, recovered = data.recovered),
             "location": Location(data)
         }
  
-        return localizers[type]
+        return models[type]

--- a/app/services/location/modelfactory.py
+++ b/app/services/location/modelfactory.py
@@ -1,0 +1,12 @@
+from ...models import *
+class ModelFactory():
+    def create_model(self, type, data):
+        """Factory Method"""
+        localizers = {
+            "timeline": Timeline(timeline = data),
+            "latest": Latest(confirmed = data.confirmed, deaths = data.deaths, recovered = data.recovered),
+            "timelines": Timelines(confirmed = data.confirmed, deaths = data.deaths, recovered = data.recovered),
+            "location": Location(data)
+        }
+ 
+        return localizers[type]

--- a/app/services/location/nyt.py
+++ b/app/services/location/nyt.py
@@ -12,6 +12,7 @@ from ...location.nyt import NYTLocation
 from ...models import Timeline
 from ...utils import httputils
 from . import LocationService
+from . import ModelFactory
 
 LOGGER = logging.getLogger("services.location.nyt")
 
@@ -99,6 +100,8 @@ async def get_locations():
 
         # The normalized locations.
         locations = []
+        modelFactory = ModelFactory()
+        model_type = "timeline"
 
         for idx, (county_state, histories) in enumerate(grouped_locations.items()):
             # Make location history for confirmed and deaths from dates.
@@ -118,19 +121,19 @@ async def get_locations():
                     coordinates=Coordinates(None, None),  # NYT does not provide coordinates
                     last_updated=datetime.utcnow().isoformat() + "Z",  # since last request
                     timelines={
-                        "confirmed": Timeline(
-                            timeline={
+                        "confirmed": modelFactory.create_model(model_type, 
+                            {
                                 datetime.strptime(date, "%Y-%m-%d").isoformat() + "Z": amount
                                 for date, amount in confirmed_history.items()
                             }
                         ),
-                        "deaths": Timeline(
-                            timeline={
+                        "deaths": modelFactory.create_model(model_type,
+                            {
                                 datetime.strptime(date, "%Y-%m-%d").isoformat() + "Z": amount
                                 for date, amount in deaths_history.items()
                             }
                         ),
-                        "recovered": Timeline(),
+                        "recovered": modelFactory.create_model(model_type,{}),
                     },
                 )
             )


### PR DESCRIPTION
####Reference Issues
From app/models.py, I find that there are several different kinds of models, like "Latest" model and "Timeline" model. This will make it hard for us to manage our code when we need to make a change. So, I think it will be helpful if some class can create the objects for us. 


####What does this implement/fix? Explain your changes.
If we use factory pattern, we can create a factory class and asks it to create class for us, we only need to pass the parameter. For example, in nyt.py, we create 3 Timeline objects, if someday we want to use another model, let say Latest object, we have to change the  Timeline to Latest for 3 times. if we use factory, we only need to create a variable named "model_type" and pass it to the constructor of factory class. Every time we want to change the model, we only need to change the "model_type" once.

I added a new ModelFactory class as our factory. This class includes a method create_model(), which will create model instance for us. In nyt.py and jhu.py, I create an insatnce of ModelFactory and asks it to create Timeline instance for us.

####Any other comments?
Thank you!